### PR TITLE
Zmienne pod parkowanie

### DIFF
--- a/stm32-atollic/SelfieF7/Src/BT/BT.c
+++ b/stm32-atollic/SelfieF7/Src/BT/BT.c
@@ -143,7 +143,42 @@ void BT_Commands(uint8_t* Buf, uint32_t length) {
 		lane_change_treshold -= 10;
 		size = sprintf((char*) txdata, "lane treshold = %dmm \r\n\r\n", lane_change_treshold);
 		HAL_UART_Transmit_DMA(&huart3, txdata, size);
-	} else if (Buf[0] == 'R')
+	}
+	// PARKOWANIE
+	else if (Buf[0] == '!') {
+		parking_turn_sharpness += 1.f;
+		size = sprintf((char*) txdata, "Kat parkowania = %.1f deg \r\n\r\n",
+				parking_turn_sharpness);
+		HAL_UART_Transmit_DMA(&huart3, txdata, size);
+	} else if (Buf[0] == '@') {
+		parking_turn_sharpness -= 1.f;
+		size = sprintf((char*) txdata, "Kat parkowania = %.1f deg \r\n\r\n",
+				parking_turn_sharpness);
+		HAL_UART_Transmit_DMA(&huart3, txdata, size);
+	} else if (Buf[0] == '#') {
+		parking_dead_fwd += 5.f;
+		size = sprintf((char*) txdata, "Start parkowania po = %.1f mm \r\n\r\n",
+				parking_dead_fwd);
+		HAL_UART_Transmit_DMA(&huart3, txdata, size);
+	} else if (Buf[0] == '$') {
+		parking_dead_fwd -= 5.f;
+		size = sprintf((char*) txdata, "Start parkowania po = %.1f mm \r\n\r\n",
+				parking_dead_fwd);
+		HAL_UART_Transmit_DMA(&huart3, txdata, size);
+	} else if (Buf[0] == '%') {
+		parking_depth += 5.f;
+		size = sprintf((char*) txdata,
+				"Glebokosc parkowania = %.1f mm \r\n\r\n", parking_dead_fwd);
+		HAL_UART_Transmit_DMA(&huart3, txdata, size);
+	} else if (Buf[0] == '^') {
+		parking_depth -= 5.f;
+		size = sprintf((char*) txdata,
+				"Glebokosc parkowania = %.1f mm \r\n\r\n", parking_dead_fwd);
+		HAL_UART_Transmit_DMA(&huart3, txdata, size);
+	}
+
+	//RESET
+	else if (Buf[0] == 'R')
 		NVIC_SystemReset();
 }
 void BluetoothRx_Irq(void) {

--- a/stm32-atollic/SelfieF7/Src/Governor/Governor.c
+++ b/stm32-atollic/SelfieF7/Src/Governor/Governor.c
@@ -24,6 +24,10 @@
 #include "tim.h"
 #include "Steering.h"
 
+float parking_depth = 10.f; // [mm]
+float parking_turn_sharpness = 40.f; // [degree]
+float parking_dead_fwd = 30.f; // [mm]
+
 uint8_t lane_switching_move = 0;
 uint8_t parking_move = 0;
 uint8_t parking_search_move =0;

--- a/stm32-atollic/SelfieF7/Src/Governor/Governor.c
+++ b/stm32-atollic/SelfieF7/Src/Governor/Governor.c
@@ -26,7 +26,7 @@
 
 float parking_depth = 10.f; // [mm]
 float parking_turn_sharpness = 40.f; // [degree]
-float parking_dead_fwd = 30.f; // [mm]
+float parking_dead_fwd = 35.f; // [mm]
 
 uint8_t lane_switching_move = 0;
 uint8_t parking_move = 0;
@@ -40,6 +40,7 @@ float crossing_dist = 0;
 
 float start_angle = 0;
 float start_distance = 0;
+float unfinished_angle = 0;
 
 
 void lane_switch_f(void);
@@ -48,6 +49,8 @@ void semi_task_f(void);
 void radio_to_actuators_f(void);
 void parking_f(void);
 void parking_search_f(void);
+void crossing_f(void);
+void await_f(void);
 
 void StartGovernorTask(void const * argument) {
 
@@ -153,8 +156,8 @@ void parking_f(void) {
 		sidesignals = SIDETURN_RIGHT;
 		steering = 90.f;
 		velocity = -500;
-		if ((CumulativeYaw - start_angle) > 35
-				|| (CumulativeYaw - start_angle) < -35) {
+		if ((CumulativeYaw - start_angle) > parking_turn_sharpness
+				|| (CumulativeYaw - start_angle) < -parking_turn_sharpness) {
 			++parking_move;
 			start_distance = fwdRoad;
 			start_angle = CumulativeYaw;
@@ -164,7 +167,7 @@ void parking_f(void) {
 		sidesignals = SIDETURN_RIGHT;
 		steering = (CumulativeYaw - start_angle);
 		velocity = -500;
-		if ((fwdRoad - start_distance) < -50) {
+		if ((fwdRoad - start_distance) < -parking_depth) {
 			++parking_move;
 			start_angle = CumulativeYaw;
 		}
@@ -173,13 +176,18 @@ void parking_f(void) {
 		sidesignals = SIDETURN_RIGHT;
 		steering = -90.f;
 		velocity = -500;
-		if ((CumulativeYaw - start_angle) > 35
-				|| (CumulativeYaw - start_angle) < -35 || flags[1] ==1) {
+		if ((CumulativeYaw - start_angle) > parking_turn_sharpness
+				|| (CumulativeYaw - start_angle) < - parking_turn_sharpness || flags[1] ==1) {
 
 			parking_angle = 0.0f;
 			set_spd = 0.0f;
 			sidesignals = SIDETURN_EMERGENCY;
 			osDelay(1200);
+			if ((CumulativeYaw - start_angle) > 0)
+				unfinished_angle = parking_turn_sharpness - (CumulativeYaw - start_angle);
+			else
+				unfinished_angle = parking_turn_sharpness + (CumulativeYaw - start_angle);
+
 			start_angle = CumulativeYaw;
 			++parking_move;
 		}
@@ -188,8 +196,8 @@ void parking_f(void) {
 		sidesignals = SIDETURN_LEFT;
 		steering = -90.f;
 		velocity = 500;
-		if ((CumulativeYaw - start_angle) > 35
-				|| (CumulativeYaw - start_angle) < -35) {
+		if ((CumulativeYaw - start_angle) > (parking_turn_sharpness - unfinished_angle)
+				|| (CumulativeYaw - start_angle) < -(parking_turn_sharpness - unfinished_angle)) {
 			++parking_move;
 			start_distance = fwdRoad;
 			start_angle = CumulativeYaw;
@@ -199,7 +207,7 @@ void parking_f(void) {
 		sidesignals = SIDETURN_LEFT;
 		steering = -(CumulativeYaw - start_angle);
 		velocity = 500;
-		if ((fwdRoad - start_distance) < 50) {
+		if ((fwdRoad - start_distance) < parking_depth) {
 			++parking_move;
 			start_angle = CumulativeYaw;
 		}
@@ -208,8 +216,8 @@ void parking_f(void) {
 		sidesignals = SIDETURN_LEFT;
 		steering = 90.f;
 		velocity = 500;
-		if ((CumulativeYaw - start_angle) > 35
-				|| (CumulativeYaw - start_angle) < -35) {
+		if ((CumulativeYaw - start_angle) > parking_turn_sharpness
+				|| (CumulativeYaw - start_angle) < -parking_turn_sharpness) {
 
 			parking_angle = 0.0f;
 			set_spd = 0.0f;

--- a/stm32-atollic/SelfieF7/Src/Governor/Governor.h
+++ b/stm32-atollic/SelfieF7/Src/Governor/Governor.h
@@ -28,5 +28,8 @@ enum autonomous_task_e
 	parking,
 }autonomous_task;
 
+float parking_depth;
+float parking_turn_sharpness;
+float parking_dead_fwd;
 
 #endif /* GOVERNOR_GOVERNOR_H_ */


### PR DESCRIPTION
+ [bugfix] dodanie brakujacego prototypu funkcji Iwo i Mateusza
+ [tweak] wyjezdzajac poprawnie wyrównuje kąt
+ dodanie i wykorzystanie zmiennych parkowania:
BT:
Kąt: +1stopien ' ! '
        -1stopien ' @'
Opoznienie: +5mm ' # '
                       -5mm ' $'
Głębokość: +5mm '% '
                     -5mm ' ^'